### PR TITLE
make all external operations use xdg-open, require child_process inst…

### DIFF
--- a/main.js
+++ b/main.js
@@ -8,7 +8,7 @@ const appMenu = require('./menu.js');
 const windowStateKeeper = require('electron-window-state');
 const app = electron.app;
 const BrowserWindow = electron.BrowserWindow;
-const shell = electron.shell;
+const child_process = require('child_process');
 
 let mainWindow;
 
@@ -56,7 +56,8 @@ app.on('ready', () => {
         /* If url isn't the actual page */
         if(url != wc.getURL()) {
           e.preventDefault();
-          electron.shell.openExternal(url);
+          const page = unescape(url).split('url=')[1];
+          child_process.execSync('xdg-open ' + page);
         }
       });
 
@@ -83,7 +84,7 @@ app.on('ready', () => {
 
     // Make ctrl+click open links in default browser, not in new electron window
     page.on('new-window', function(url) {
-          child_process.execSync('xdg-open' + url)
+          child_process.execSync('xdg-open ' + url);
     });
 });
 

--- a/menu.js
+++ b/menu.js
@@ -2,7 +2,7 @@
 
 const electron = require('electron');
 const app = electron;
-const shell = electron.shell;
+const child_process = require('child_process');
 
 // when we start there is no appName yet, hardcode it for now
 const appName = 'snapcraft.io';
@@ -79,7 +79,7 @@ const Template = [
                 label: `https://snapcraft.io`,
                 accelerator: 'CmdOrCtrl+H',
                 click() {
-                    shell.openExternal('https://snapcraft.io');
+                    child_process.execSync('xdg-open https://snapcraft.io');
                 }
             }
         ]


### PR DESCRIPTION
…ead of shell, adjust xdg-open syntax for ctrl+click

this should fix https://github.com/ryanleesipes/snapcraft-forum/issues/1 for all desktops that have snapd-xdg-open installed.